### PR TITLE
Update google/dart base images in Dockerfiles to 2.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.7
+FROM google/dart:2.10
 
 ENV INDEXER_COMMIT=9987ef9325e08fa3f650c88ef28e2074f6fcaadf
 


### PR DESCRIPTION
This updates google/dart base images used in Dockerfiles to version 2.10.2

[_Created by Sourcegraph batch change `ramihamdan/update-dart-base-images-2-10`._](https://demo.sourcegraph.com/users/ramihamdan/batch-changes/update-dart-base-images-2-10)